### PR TITLE
Improve PHP version tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 php:
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
   - nightly
 before_install:
   - phpenv config-rm xdebug.ini || true;
@@ -14,7 +14,7 @@ install:
   - composer update $COMPOSER_FLAGS
 
 script:
-  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]]; then  vendor/bin/phpcs; fi
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.4" ]]; then  vendor/bin/phpcs; fi
   - vendor/bin/phpstan analyse
   - vendor/bin/psalm
   - vendor/bin/phpunit


### PR DESCRIPTION
# Changed log
- Using `php-7.4` version test during Travis CI build.
- Using `phpcs` coding style tool during `php-7.4` version test.